### PR TITLE
[Hotfix] "No deliveries scheduled" screen in Assign volunteers

### DIFF
--- a/src/PageContent/AssignVolunteers/AssignVolunteersController.js
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersController.js
@@ -13,7 +13,7 @@ class AssignVolunteersController extends Component {
         this.state = {
             deliveries: {},
             hitUpdateTime: -1,
-            deliveriesExist: true,
+            deliveriesExist: false,
             onConfirm: false,
             step: 0,
             selectedDeliveryId: -1,
@@ -58,10 +58,8 @@ class AssignVolunteersController extends Component {
 
         let processTimestampIndex = (timestampIndex) => {
             for (let deliveryId of Object.keys(timestampIndex)) {
+                this.setState({deliveriesExist: true});
                 if (!this.state.deliveries[deliveryId]) {
-                    if (!this.state.deliveriesExist) {
-                        this.setState({deliveriesExist: true});
-                    }
                     genDeliveryListener(deliveryId);
                 }
             }
@@ -94,7 +92,6 @@ class AssignVolunteersController extends Component {
                     /> :
                     <div />
                 }
-
             </div>
         );
 

--- a/src/PageContent/AssignVolunteers/AssignVolunteersController.js
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersController.js
@@ -13,8 +13,8 @@ class AssignVolunteersController extends Component {
         this.state = {
             deliveries: {},
             hitUpdateTime: -1,
-            deliveriesExist: true,
-            finishedCall: true,
+            deliveriesExist: false,
+            finishedCall: false,
             onConfirm: false,
             step: 0,
             selectedDeliveryId: -1,
@@ -58,6 +58,7 @@ class AssignVolunteersController extends Component {
             .orderByKey().startAt(`${moment().valueOf()}`);
 
         let processTimestampIndex = (timestampIndex) => {
+            console.log("test 2!");
             for (let deliveryId of Object.keys(timestampIndex)) {
                 if (!this.state.deliveries[deliveryId]) {
                     genDeliveryListener(deliveryId);
@@ -65,8 +66,14 @@ class AssignVolunteersController extends Component {
             }
         };
 
+        let updateLoading = (children, myDeliveriesRef) => {
+            if(children) { this.setState({deliveriesExist : true}); }
+            this.setState({finishedCall : true});
+        }
+
         myDeliveriesRef.on('child_added', async (snap) => processTimestampIndex(snap.val()));
         myDeliveriesRef.on('child_changed', async (snap) => processTimestampIndex(snap.val()));
+        myDeliveriesRef.once('value', (snap) => updateLoading(snap.val(), myDeliveriesRef));
     }
 
 
@@ -177,11 +184,12 @@ class AssignVolunteersController extends Component {
             return (
                 this.state.finishedCall ? 
                 <AssignVolunteersIndex 
-                    handleEditClick={this.handleEditClick.bind(this)}
-                    deliveries={this.state.deliveries}
-                    deliveriesExist={this.state.deliveriesExist}
-                /> :
+                handleEditClick={this.handleEditClick.bind(this)}
+                deliveries={this.state.deliveries}
+                deliveriesExist={this.state.deliveriesExist} 
+                /> : 
                 <div>Loading...</div>
+
             );
 
         case 1:

--- a/src/PageContent/AssignVolunteers/AssignVolunteersController.js
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersController.js
@@ -13,7 +13,8 @@ class AssignVolunteersController extends Component {
         this.state = {
             deliveries: {},
             hitUpdateTime: -1,
-            deliveriesExist: false,
+            deliveriesExist: true,
+            finishedCall: true,
             onConfirm: false,
             step: 0,
             selectedDeliveryId: -1,
@@ -58,15 +59,16 @@ class AssignVolunteersController extends Component {
 
         let processTimestampIndex = (timestampIndex) => {
             for (let deliveryId of Object.keys(timestampIndex)) {
-                this.setState({deliveriesExist: true});
                 if (!this.state.deliveries[deliveryId]) {
                     genDeliveryListener(deliveryId);
                 }
             }
         };
+
         myDeliveriesRef.on('child_added', async (snap) => processTimestampIndex(snap.val()));
         myDeliveriesRef.on('child_changed', async (snap) => processTimestampIndex(snap.val()));
     }
+
 
     componentWillUnmount() {
         // detach all listeners
@@ -173,11 +175,13 @@ class AssignVolunteersController extends Component {
         switch(this.state.step) {
         case 0:
             return (
+                this.state.finishedCall ? 
                 <AssignVolunteersIndex 
                     handleEditClick={this.handleEditClick.bind(this)}
                     deliveries={this.state.deliveries}
                     deliveriesExist={this.state.deliveriesExist}
-                />
+                /> :
+                <div>Loading...</div>
             );
 
         case 1:

--- a/src/PageContent/AssignVolunteers/AssignVolunteersController.js
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersController.js
@@ -58,7 +58,6 @@ class AssignVolunteersController extends Component {
             .orderByKey().startAt(`${moment().valueOf()}`);
 
         let processTimestampIndex = (timestampIndex) => {
-            console.log("test 2!");
             for (let deliveryId of Object.keys(timestampIndex)) {
                 if (!this.state.deliveries[deliveryId]) {
                     genDeliveryListener(deliveryId);

--- a/src/PageContent/AssignVolunteers/AssignVolunteersController.js
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersController.js
@@ -70,6 +70,8 @@ class AssignVolunteersController extends Component {
             this.setState({finishedCall : true});
         }
 
+        // TODO: Currently a redundant call on child added and value when initialized. There
+        // may be a better way to do this without the redundancy
         myDeliveriesRef.on('child_added', async (snap) => processTimestampIndex(snap.val()));
         myDeliveriesRef.on('child_changed', async (snap) => processTimestampIndex(snap.val()));
         myDeliveriesRef.once('value', (snap) => updateLoading(snap.val(), myDeliveriesRef));

--- a/src/PageContent/AssignVolunteers/AssignVolunteersIndex.css
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersIndex.css
@@ -28,3 +28,4 @@
     margin-bottom: 4px;
     box-shadow: none;
 }
+

--- a/src/PageContent/AssignVolunteers/AssignVolunteersIndex.js
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersIndex.js
@@ -7,8 +7,8 @@ class AssignVolunteersIndex extends Component {
     render() {
         const {
             deliveries,
-            deliveriesExist,
             handleEditClick,
+            deliveriesExist
         } = this.props;
 
         //if(Object.keys(deliveries).length === 0) {

--- a/src/PageContent/AssignVolunteers/AssignVolunteersIndex.js
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersIndex.js
@@ -11,8 +11,9 @@ class AssignVolunteersIndex extends Component {
             handleEditClick,
         } = this.props;
 
-        if(!deliveriesExist) {
-            return <h5>No deliveries scheduled</h5>;
+        //if(Object.keys(deliveries).length === 0) {
+        if(!deliveriesExist) { 
+            return <h5>No deliveries scheduled at this time... keep an eye out for more openings!</h5>;
         } else {
             return (
                 <div className="avi-container">  

--- a/src/PageContent/AssignVolunteers/AssignVolunteersIndex.js
+++ b/src/PageContent/AssignVolunteers/AssignVolunteersIndex.js
@@ -13,7 +13,7 @@ class AssignVolunteersIndex extends Component {
 
         //if(Object.keys(deliveries).length === 0) {
         if(!deliveriesExist) { 
-            return <h5>No deliveries scheduled at this time... keep an eye out for more openings!</h5>;
+            return <h3>No Deliveries Found</h3>;
         } else {
             return (
                 <div className="avi-container">  


### PR DESCRIPTION
Loading screen for Assign volunteers

**Changes:**
Added a listener that only checks when the component first mounts to see if there are any deliveries available. When it gets back a response it updates from loading to the Assign Volunteers page, and correctly displays whether or not there are deliveries.

**Possible Next Step:**
Adjust styling of "No deliveries found" to look like the Food Logs page when no food logs are found.